### PR TITLE
Update SDK dependencies versions

### DIFF
--- a/00-Login/app/build.gradle
+++ b/00-Login/app/build.gradle
@@ -20,7 +20,7 @@ android {
 }
 
 dependencies {
-    compile 'com.auth0.android:auth0:1.12.0'
+    compile 'com.auth0.android:auth0:1.+'
     compile 'com.android.support:appcompat-v7:25.3.1'
     testCompile 'junit:junit:4.12'
 }

--- a/03-Session-Handling/app/build.gradle
+++ b/03-Session-Handling/app/build.gradle
@@ -24,6 +24,6 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
     compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.auth0.android:auth0:1.12.0'
+    compile 'com.auth0.android:auth0:1.+'
     compile 'com.squareup.picasso:picasso:2.5.2'
 }

--- a/04-User-Profile/app/build.gradle
+++ b/04-User-Profile/app/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
     compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.auth0.android:jwtdecode:1.1.1'
-    compile 'com.auth0.android:auth0:1.12.0'
+    compile 'com.auth0.android:jwtdecode:1.+'
+    compile 'com.auth0.android:auth0:1.+'
     compile 'com.squareup.picasso:picasso:2.5.2'
 }

--- a/05-Linking-Accounts/app/build.gradle
+++ b/05-Linking-Accounts/app/build.gradle
@@ -24,6 +24,6 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
     compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.auth0.android:auth0:1.12.0'
+    compile 'com.auth0.android:auth0:1.+'
     compile 'com.squareup.picasso:picasso:2.5.2'
 }

--- a/06-Calling-APIs/app/build.gradle
+++ b/06-Calling-APIs/app/build.gradle
@@ -21,7 +21,7 @@ android {
 
 dependencies {
     compile 'com.squareup.okhttp:okhttp:2.7.5'
-    compile 'com.auth0.android:auth0:1.12.0'
+    compile 'com.auth0.android:auth0:1.+'
     compile 'com.android.support:appcompat-v7:25.3.1'
     testCompile 'junit:junit:4.12'
 }

--- a/07-Authorization/app/build.gradle
+++ b/07-Authorization/app/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
     compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.auth0.android:auth0:1.12.0'
-    compile 'com.auth0.android:jwtdecode:1.1.1'
+    compile 'com.auth0.android:auth0:1.+'
+    compile 'com.auth0.android:jwtdecode:1.+'
     compile 'com.squareup.picasso:picasso:2.5.2'
 }


### PR DESCRIPTION
This PR makes the samples always use the latest minor/patch versions of the SDKs. We follow semver so this shouldn't be an issue. Also helps us keeping it up to date without us having to manually update the code.