### PR TITLE
Update sample apps [QS-412]

### DIFF
--- a/00-Login/app/src/main/res/values/strings.xml.example
+++ b/00-Login/app/src/main/res/values/strings.xml.example
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Hosted Login Page</string>
+    <string name="app_name">Login</string>
 
     <string name="com_auth0_client_id">{CLIENT_ID}</string>
     <string name="com_auth0_domain">{DOMAIN}</string>

--- a/00-Login/build.gradle
+++ b/00-Login/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.5.2'
     }
 
 }

--- a/00-Login/gradle/wrapper/gradle-wrapper.properties
+++ b/00-Login/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Fri Nov 29 14:05:57 ART 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/03-Session-Handling/build.gradle
+++ b/03-Session-Handling/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.5.2'
     }
 }
 

--- a/03-Session-Handling/gradle/wrapper/gradle-wrapper.properties
+++ b/03-Session-Handling/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Fri Nov 29 14:11:14 ART 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/04-User-Profile/build.gradle
+++ b/04-User-Profile/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.5.2'
     }
 }
 

--- a/04-User-Profile/gradle/wrapper/gradle-wrapper.properties
+++ b/04-User-Profile/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Fri Nov 29 14:18:09 ART 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/05-Linking-Accounts/app/src/main/java/com/auth0/samples/activities/LoginActivity.java
+++ b/05-Linking-Accounts/app/src/main/java/com/auth0/samples/activities/LoginActivity.java
@@ -26,7 +26,9 @@ import com.auth0.android.result.Credentials;
 import com.auth0.android.result.UserIdentity;
 import com.auth0.samples.R;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 
 public class LoginActivity extends AppCompatActivity {
@@ -135,10 +137,17 @@ public class LoginActivity extends AppCompatActivity {
     }
 
     private void doLogin() {
+        Map<String, Object> parameters = new HashMap<>();
+
+        if (linkSessions) {
+            parameters.put("prompt", "login");
+        }
+
         WebAuthProvider.login(auth0)
                 .withScheme("demo")
                 .withAudience(String.format("https://%s/api/v2/", getString(R.string.com_auth0_domain)))
                 .withScope("openid profile email offline_access read:current_user update:current_user_identities")
+                .withParameters(parameters)
                 .start(this, loginCallback);
     }
 

--- a/05-Linking-Accounts/build.gradle
+++ b/05-Linking-Accounts/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.5.2'
     }
 }
 

--- a/05-Linking-Accounts/gradle/wrapper/gradle-wrapper.properties
+++ b/05-Linking-Accounts/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Fri Nov 29 13:59:55 ART 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/06-Calling-APIs/app/src/main/java/com/auth0/samples/LoginActivity.java
+++ b/06-Calling-APIs/app/src/main/java/com/auth0/samples/LoginActivity.java
@@ -36,6 +36,8 @@ public class LoginActivity extends Activity {
      */
     @SuppressWarnings("unused")
     private static final int CODE_DEVICE_AUTHENTICATION = 22;
+    private static final String API_IDENTIFIER = "YOUR API IDENTIFIER";
+
     public static final String EXTRA_CLEAR_CREDENTIALS = "com.auth0.CLEAR_CREDENTIALS";
     public static final String EXTRA_ACCESS_TOKEN = "com.auth0.ACCESS_TOKEN";
     public static final String EXTRA_ID_TOKEN = "com.auth0.ID_TOKEN";
@@ -109,7 +111,7 @@ public class LoginActivity extends Activity {
     private void doLogin() {
         WebAuthProvider.login(auth0)
                 .withScheme("demo")
-                .withAudience(String.format("https://%s/userinfo", getString(R.string.com_auth0_domain)))
+                .withAudience(API_IDENTIFIER)
                 .withScope("openid offline_access")
                 .start(this, loginCallback);
     }

--- a/06-Calling-APIs/app/src/main/res/values/strings.xml.example
+++ b/06-Calling-APIs/app/src/main/res/values/strings.xml.example
@@ -1,6 +1,7 @@
 <resources>
     <string name="app_name">Calling APIs</string>
     <string name="login">Log in</string>
+    <string name="logout">Log out</string>
     <string name="callAPIWithToken">Call API with Token</string>
     <string name="callAPIWithoutToken">Call API without Token</string>
 

--- a/06-Calling-APIs/build.gradle
+++ b/06-Calling-APIs/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.5.2'
     }
 }
 

--- a/06-Calling-APIs/gradle/wrapper/gradle-wrapper.properties
+++ b/06-Calling-APIs/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Fri Nov 29 11:51:02 ART 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/07-Authorization/app/src/main/java/com/auth0/samples/activities/MainActivity.java
+++ b/07-Authorization/app/src/main/java/com/auth0/samples/activities/MainActivity.java
@@ -23,7 +23,7 @@ import java.util.List;
 public class MainActivity extends AppCompatActivity {
 
     //Use the same Claim name as defined in the Rule
-    private static final String ROLES_CLAIM = "https://access.control/roles";
+    private static final String ROLES_CLAIM = "https://example.com/roles";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/07-Authorization/build.gradle
+++ b/07-Authorization/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.5.2'
     }
 }
 

--- a/07-Authorization/gradle/wrapper/gradle-wrapper.properties
+++ b/07-Authorization/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jun 28 17:52:07 ART 2019
+#Fri Nov 29 14:33:45 ART 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
- Updated Gradle plugin to version `3.5.2`.
- Added `prompt: login` parameter in sample **05-Linking-Accounts** to fix the login for the secondary account.
- Added the missing `API_IDENTIFIER` in sample **06-Calling-APIs**.
- Updated the roles claim string in sample **07-Authorization** to match the one in the sample rule script.
- Changed the `app_name` in sample **00-Login** to match the exercise name.

The fixes in the docs can be found in [this PR](https://github.com/auth0/docs/pull/8535).