### PR TITLE
Update Android Gradle Plugin

### DIFF
--- a/00-Login/build.gradle
+++ b/00-Login/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:3.5.4'
     }
 
 }

--- a/03-Session-Handling/build.gradle
+++ b/03-Session-Handling/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:3.5.4'
     }
 }
 

--- a/04-User-Profile/build.gradle
+++ b/04-User-Profile/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:3.5.4'
     }
 }
 

--- a/05-Linking-Accounts/build.gradle
+++ b/05-Linking-Accounts/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:3.5.4'
     }
 }
 

--- a/06-Calling-APIs/build.gradle
+++ b/06-Calling-APIs/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:3.5.4'
     }
 }
 

--- a/07-Authorization/build.gradle
+++ b/07-Authorization/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:3.5.4'
     }
 }
 


### PR DESCRIPTION
Fixes #90 and #92

Auth0.Android version 1.26.0 introduced the `queries` element to the Android manifest file, which requires an update to the Android Gradle Plugin, as documented in the [1.26.0 Release Notes](https://github.com/auth0/Auth0.Android/releases/tag/1.26.0).

This changes bumps the Android Gradle Plugin to version `3.5.4` to address this, as documented in the [Android announcement blog post](https://android-developers.googleblog.com/2020/07/preparing-your-build-for-package-visibility-in-android-11.html).