### PR TITLE
[SDK-2245] Additions to sample to add reading and writing of user metadata

### DIFF
--- a/00-Login-Kt/app/src/main/java/com/auth0/sample/MainActivity.kt
+++ b/00-Login-Kt/app/src/main/java/com/auth0/sample/MainActivity.kt
@@ -102,19 +102,19 @@ class MainActivity : AppCompatActivity() {
     private fun showUserProfile() {
         val client = AuthenticationAPIClient(account)
 
-        // Use the access token to call userInfo endpoint
-        cachedCredentials?.accessToken?.let { accessToken ->
-            client.userInfo(accessToken)
-                .start(object : Callback<UserProfile, AuthenticationException> {
-                    override fun onFailure(exception: AuthenticationException) {
-                        showSnackBar("Failure: ${exception.getCode()}")
-                    }
+        // Use the access token to call userInfo endpoint.
+        // In this sample, we can assume cachedCredentials has been initialized by this point.
+        client.userInfo(cachedCredentials!!.accessToken!!)
+            .start(object : Callback<UserProfile, AuthenticationException> {
+                override fun onFailure(exception: AuthenticationException) {
+                    showSnackBar("Failure: ${exception.getCode()}")
+                }
 
-                    override fun onSuccess(profile: UserProfile?) {
-                        cachedUserProfile = profile;
-                        updateUI()
-                    }
-        }) }
+                override fun onSuccess(profile: UserProfile?) {
+                    cachedUserProfile = profile;
+                    updateUI()
+                }
+        })
     }
 
     private fun getUserMetadata() {
@@ -131,7 +131,7 @@ class MainActivity : AppCompatActivity() {
                 cachedUserProfile = userProfile;
                 updateUI()
 
-                val country = cachedUserProfile?.getUserMetadata()?.get("country").toString() ?: ""
+                val country = userProfile!!.getUserMetadata()["country"] as String? ?: ""
                 binding.inputEditMetadata.setText(country)
             }
         })

--- a/00-Login-Kt/app/src/main/java/com/auth0/sample/MainActivity.kt
+++ b/00-Login-Kt/app/src/main/java/com/auth0/sample/MainActivity.kt
@@ -45,22 +45,16 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun updateUI() {
-        if (cachedCredentials != null) {
-            binding.buttonLogout.isEnabled = true
-            binding.metadataPanel.isVisible = true
-            binding.buttonLogin.isEnabled = false
-        } else {
-            binding.buttonLogout.isEnabled = false
-            binding.metadataPanel.isVisible = false
-            binding.buttonLogin.isEnabled = true
-        }
+        binding.buttonLogout.isEnabled = cachedCredentials != null
+        binding.metadataPanel.isVisible = cachedCredentials != null
+        binding.buttonLogin.isEnabled = cachedCredentials == null
+        binding.userProfile.isVisible = cachedCredentials != null
 
-        if (cachedUserProfile != null) {
-            binding.userProfile.text =
-                    "Name: ${cachedUserProfile?.name}\n" +
-                    "Email: ${cachedUserProfile?.email}"
-        } else {
-            binding.userProfile.text = ""
+        binding.userProfile.text =
+            "Name: ${cachedUserProfile?.name ?: ""}\n" +
+            "Email: ${cachedUserProfile?.email ?: ""}"
+
+        if (cachedUserProfile == null) {
             binding.inputEditMetadata.setText("")
         }
     }

--- a/00-Login-Kt/app/src/main/java/com/auth0/sample/MainActivity.kt
+++ b/00-Login-Kt/app/src/main/java/com/auth0/sample/MainActivity.kt
@@ -131,7 +131,7 @@ class MainActivity : AppCompatActivity() {
                 cachedUserProfile = userProfile;
                 updateUI()
 
-                val country = userProfile!!.getUserMetadata()["country"] as String? ?: ""
+                val country = userProfile!!.getUserMetadata()["country"] as String?
                 binding.inputEditMetadata.setText(country)
             }
         })

--- a/00-Login-Kt/app/src/main/java/com/auth0/sample/MainActivity.kt
+++ b/00-Login-Kt/app/src/main/java/com/auth0/sample/MainActivity.kt
@@ -73,7 +73,7 @@ class MainActivity : AppCompatActivity() {
                 }
 
                 override fun onSuccess(credentials: Credentials?) {
-                    cachedCredentials = credentials!!
+                    cachedCredentials = credentials
                     showSnackBar("Success: ${credentials?.accessToken}")
                     updateUI()
                     showUserProfile()

--- a/00-Login-Kt/app/src/main/java/com/auth0/sample/MainActivity.kt
+++ b/00-Login-Kt/app/src/main/java/com/auth0/sample/MainActivity.kt
@@ -69,22 +69,12 @@ class MainActivity : AppCompatActivity() {
             // Launch the authentication passing the callback where the results will be received
             .start(this, object : Callback<Credentials, AuthenticationException> {
                 override fun onFailure(exception: AuthenticationException) {
-                    Snackbar.make(
-                        binding.root,
-                        "Failure: ${exception.getCode()}",
-                        Snackbar.LENGTH_LONG
-                    ).show()
+                    showSnackBar("Failure: ${exception.getCode()}")
                 }
 
                 override fun onSuccess(credentials: Credentials?) {
                     cachedCredentials = credentials!!
-
-                    Snackbar.make(
-                        binding.root,
-                        "Success: ${credentials?.accessToken}",
-                        Snackbar.LENGTH_LONG
-                    ).show()
-
+                    showSnackBar("Success: ${credentials?.accessToken}")
                     updateUI()
                     showUserProfile()
                 }
@@ -104,12 +94,7 @@ class MainActivity : AppCompatActivity() {
 
                     override fun onFailure(exception: AuthenticationException) {
                         updateUI()
-
-                        Snackbar.make(
-                                binding.root,
-                                "Failure: ${exception.message}",
-                        Snackbar.LENGTH_LONG
-                        ).show()
+                        showSnackBar("Failure: ${exception.getCode()}")
                     }
                 })
     }
@@ -122,11 +107,7 @@ class MainActivity : AppCompatActivity() {
             client.userInfo(accessToken)
                 .start(object : Callback<UserProfile, AuthenticationException> {
                     override fun onFailure(exception: AuthenticationException) {
-                        Snackbar.make(
-                            binding.root,
-                            "Failure: ${exception.getCode()}",
-                            Snackbar.LENGTH_LONG
-                        ).show()
+                        showSnackBar("Failure: ${exception.getCode()}")
                     }
 
                     override fun onSuccess(profile: UserProfile?) {
@@ -147,54 +128,24 @@ class MainActivity : AppCompatActivity() {
                 // Get the full user profile
                 usersClient.getProfile(userId).start(object: Callback<UserProfile, ManagementException> {
                     override fun onFailure(exception: ManagementException) {
-                        Snackbar.make(
-                                binding.root,
-                                "Failure: ${exception.getCode()}",
-                                Snackbar.LENGTH_LONG
-                        ).show()
+                        showSnackBar("Failure: ${exception.getCode()}")
                     }
 
                     override fun onSuccess(userProfile: UserProfile?) {
                         cachedUserProfile = userProfile;
                         updateUI()
-                        binding.inputEditMetadata.setText(cachedUserProfile?.getUserMetadata()?.get("country") as String? ?: "")
+                        showSnackBar("Successful")
                     }
                 })
             }
         }
     }
 
-    private fun patchUserMetadata() {
-        // Get the access token so that we can make calls to the management API
-        cachedCredentials?.accessToken?.let { accessToken ->
-            // Get the user ID and call the full getUser Management API endpoint, to retrieve the full profile information
-            cachedUserProfile?.getId()?.let { userId ->
-                val usersClient = UsersAPIClient(account, accessToken)
-                val metadata = mapOf("country" to binding.inputEditMetadata.getText().toString())
-
-                usersClient
-                        .updateMetadata(userId, metadata)
-                        .start(object: Callback<UserProfile, ManagementException> {
-                            override fun onFailure(exception: ManagementException) {
-                                Snackbar.make(
-                                    binding.root,
-                                    "Failure: ${exception.getCode()}",
-                                    Snackbar.LENGTH_LONG
-                                ).show()
-                            }
-
-                            override fun onSuccess(profile: UserProfile?) {
-                                cachedUserProfile = profile
-                                updateUI()
-
-                                Snackbar.make(
-                                        binding.root,
-                                        "Successful",
-                                        Snackbar.LENGTH_LONG
-                                ).show()
-                            }
-                        })
-            }
-        }
+    private fun showSnackBar(text: String) {
+        Snackbar.make(
+            binding.root,
+            text,
+            Snackbar.LENGTH_LONG
+        ).show()
     }
 }

--- a/00-Login-Kt/app/src/main/res/layout/activity_main.xml
+++ b/00-Login-Kt/app/src/main/res/layout/activity_main.xml
@@ -8,7 +8,7 @@
 
     <Button
         android:id="@+id/button_login"
-        android:layout_width="wrap_content"
+        android:layout_width="200dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="36dp"
         android:text="Authenticate"
@@ -18,12 +18,22 @@
 
     <Button
         android:id="@+id/button_logout"
-        android:layout_width="wrap_content"
+        android:layout_width="200dp"
         android:layout_height="wrap_content"
         android:text="Log out"
+        android:enabled="false"
         app:layout_constraintEnd_toEndOf="@+id/textView"
         app:layout_constraintStart_toStartOf="@+id/textView"
         app:layout_constraintTop_toBottomOf="@+id/button_login" />
+
+    <TextView
+        android:id="@+id/user_profile"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/button_logout"
+        android:layout_margin="18dp"/>
 
     <TextView
         android:id="@+id/textView"
@@ -36,22 +46,60 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <TextView
-        android:id="@+id/userProfile"
+    <LinearLayout
+        android:id="@+id/metadata_panel"
+        android:visibility="invisible"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:gravity="center"
+        android:layout_marginTop="16dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/button_logout"
-        android:layout_margin="18dp"/>
+        app:layout_constraintTop_toBottomOf="@id/user_profile">
 
-    <TextView
-        android:id="@+id/userMeta"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/userProfile"
-        android:layout_margin="18dp"/>
+        <TextView
+            android:id="@+id/text_heading_metadata"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textStyle="bold"
+            android:text="Metadata"/>
+
+        <TextView
+            android:id="@+id/text_info_metadata"
+            android:layout_width="match_parent"
+            android:layout_height="50dp"
+            android:layout_margin="8dp"
+            android:textAlignment="center"
+            android:text="Use the buttons and text box below to patch the 'country' field from 'user_metadata'"
+            android:textSize="12sp" />
+
+        <EditText
+            android:id="@+id/input_edit_metadata"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center">
+            <Button
+                android:id="@+id/button_get_metadata"
+                android:layout_width="100dp"
+                android:layout_height="wrap_content"
+                android:text="Get"
+                android:layout_marginRight="8dp"/>
+
+            <Button
+                android:id="@+id/button_patch_metadata"
+                android:layout_width="100dp"
+                android:layout_height="wrap_content"
+                android:text="Patch"
+                android:layout_marginLeft="8dp"/>
+        </LinearLayout>
+    </LinearLayout>
+
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/00-Login-Kt/app/src/main/res/layout/activity_main.xml
+++ b/00-Login-Kt/app/src/main/res/layout/activity_main.xml
@@ -43,6 +43,15 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/button_logout"
-        android:layout_margin="36dp"/>
+        android:layout_margin="18dp"/>
+
+    <TextView
+        android:id="@+id/userMeta"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/userProfile"
+        android:layout_margin="18dp"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
This PR builds on the existing `feat-kotlin` branch to flesh out the sample with the capability to read and write user metadata. It contains some amendments to the UI to make this task easier from a user perspective.

This sample covers both chapters that appear in the accompanying quickstart.

![image](https://user-images.githubusercontent.com/766403/104727800-ddb98580-572d-11eb-905e-3a8820fe4de3.png)
