### PR TITLE
Migrate v1 Quickstart Articles to Tutorial files

### DIFF
--- a/00-Login/README.md
+++ b/00-Login/README.md
@@ -2,7 +2,7 @@
 
 This sample shows how to authenticate users using Auth0 and obtain their tokens. 
 
-A step by step [Quickstart Tutorial](https://auth0.com/docs/quickstart/native/android/00-login) is provided in our site. If you prefer to skip it and run the sample make sure to [setup](#setup) the project first.
+> A step by step [Tutorial](./TUTORIAL.md) is also provided. If you prefer to skip it and run the sample make sure to [setup](#setup) the project first.
 
 ### Requirements
 

--- a/00-Login/TUTORIAL.md
+++ b/00-Login/TUTORIAL.md
@@ -1,0 +1,216 @@
+# Tutorial
+
+_This content has been extracted from a previous version of the [Auth0 Android Quickstart](https://auth0.com/docs/quickstart/native/android) and demonstrates how to integrate Auth0 with an Android application using the [Auth0 Android](https://github.com/auth0/Auth0.Android) SDK._
+
+## Configure Auth0
+
+### Get Your Application Keys
+
+When you signed up for Auth0, a new application was created for you, or you could have created a new one. You will need some details about that application to communicate with Auth0. You can get these details from the Application Settings section in the Auth0 dashboard.
+
+> When using the Default App with a Native or Single Page Application, ensure to update the **Token Endpoint Authentication Method** to `None` and set the **Application Type** to either `SPA` or `Native`. 
+
+You need the following information:
+
+- Domain
+- Client ID
+
+We suggest you do not hardcode these values as you may need to change them in the future. Instead, use [String Resources](https://developer.android.com/guide/topics/resources/string-resource.html), such as `@string/com_auth0_domain`, to define the values. 
+
+Edit your `res/values/strings.xml` file as follows:
+
+```xml
+<resources>
+    <string name="com_auth0_client_id">{YOUR_CLIENT_ID}</string>
+    <string name="com_auth0_domain">{YOUR_AUTH0_DOMAIN}</string>
+</resources>
+```
+
+### Configure Callback URLs
+
+A callback URL is a URL in your application where Auth0 redirects the user after they have authenticated. The callback URL for your app must be added to the **Allowed Callback URLs** field in your Application Settings. If this field is not set, users will be unable to log in to the application and will get an error.
+
+### Configure Logout URLs
+
+A logout URL is a URL in your application that Auth0 can return to after the user has been logged out of the authorization server. This is specified in the `returnTo` query parameter. The logout URL for your app must be added to the **Allowed Logout URLs** field in your Application Settings. If this field is not set, users will be unable to log out from the application and will get an error.
+
+Replace `YOUR_APP_PACKAGE_NAME` with your application's package name, available as the `applicationId` attribute in the `app/build.gradle` file.
+
+## Add the Auth0 Android Dependency
+
+Add the [Auth0 Android](https://github.com/auth0/Auth0.Android) SDK into your project. The library will make requests to the Auth0's Authentication and Management APIs.
+
+### Add Auth0 to Gradle
+
+In your app's `build.gradle` dependencies section, add the following:
+
+```groovy
+apply plugin: 'com.android.application'
+android {
+  // ...
+}
+dependencies {
+  // Add the Auth0 Android SDK
+  implementation 'com.auth0.android:auth0:1.+'
+}
+```
+
+> If Android Studio lints the `+` sign, or if you want to use a fixed version, check for the latest in [Maven](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22auth0%22%20g%3A%22com.auth0.android%22) or [JCenter](https://bintray.com/auth0/android/auth0). Remember to synchronize using the Android Studio prompt or run `./gradlew clean build` from the command line. For more information about Gradle usage, check [their official documentation](http://tools.android.com/tech-docs/new-build-system/user-guide).
+
+Add manifest placeholders required by the SDK. The placeholders are used internally to define an `intent-filter` that captures the authentication callback URL.
+
+To add the manifest placeholders, add the next line:
+
+```
+// app/build.gradle
+
+apply plugin: 'com.android.application'
+compileSdkVersion 28
+android {
+    defaultConfig {
+        applicationId "com.auth0.samples"
+        minSdkVersion 15
+        targetSdkVersion 28
+        // ...
+
+        // ---> Add the next line
+        manifestPlaceholders = [auth0Domain: "@string/com_auth0_domain", auth0Scheme: "demo"]
+        // <---
+    }
+}
+```
+
+> You do not need to declare a specific `intent-filter` for your activity, because you have defined the manifest placeholders with your Auth0 **Domain** and **Scheme** values and the library will handle the redirection for you.
+
+The `AndroidManifest.xml` file should look like this:
+
+```xml
+<!-- app/src/main/AndroidManifest.xml -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.auth0.samples">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:theme="@style/AppTheme">
+
+        <activity android:name="com.auth0.samples.MainActivity">
+          <intent-filter>
+              <action android:name="android.intent.action.MAIN" />
+              <category android:name="android.intent.category.LAUNCHER" />
+          </intent-filter>
+        </activity>
+
+    </application>
+
+</manifest>
+```
+
+Run **Sync Project with Gradle Files** inside Android Studio or execute `./gradlew clean assembleDebug` from the command line.
+
+> For more information about using Gradle, check the [Gradle official documentation](https://gradle.org/getting-started-android-build/).
+
+## Add Authentication with Auth0
+
+[Universal Login](https://auth0.com/docs/universal-login) is the easiest way to set up authentication in your application. We recommend using it for the best experience, best security and the fullest array of features.
+
+In the `onCreate` method, create a new instance of the `Auth0` class to hold user credentials and set it to be OIDC conformant.
+
+You can use a constructor that receives an Android Context if you have added the following String resources:
+- `R.string.com_auth0_client_id`
+- `R.string.com_auth0_domain`
+
+```java
+// app/src/main/java/com/auth0/samples/MainActivity.java
+
+private Auth0 auth0;
+
+@Override
+protected void onCreate(@Nullable Bundle savedInstanceState) {
+    // ...
+    auth0 = new Auth0(this);
+    auth0.setOIDCConformant(true);
+}
+```
+
+Otherwise, use the constructor that receives both strings.
+
+Finally, create a `login` method and use the `WebAuthProvider` class to authenticate with any connection you enabled on your application in the Auth0 dashboard.
+
+```java
+// app/src/main/java/com/auth0/samples/LoginActivity.java
+
+private void login() {
+    WebAuthProvider.login(auth0)
+            .withScheme("demo")
+            .withAudience(String.format("https://%s/userinfo", getString(R.string.com_auth0_domain)))
+            .start(MainActivity.this, new AuthCallback() {
+                @Override
+                public void onFailure(@NonNull Dialog dialog) {
+                    // Show error Dialog to user
+                }
+
+                @Override
+                public void onFailure(AuthenticationException exception) {
+                    // Show error to user
+                }
+
+                @Override
+                public void onSuccess(@NonNull Credentials credentials) {
+                    // Store credentials
+                    // Navigate to your main activity
+                }
+        });
+}
+```
+
+After you call the `WebAuthProvider#start` function, the browser launches and shows the Authentication page. Once the user authenticates, the callback URL is called. The callback URL contains the final result of the authentication process.
+
+## Logout
+
+Use `WebAuthProvider` to remove the cookie set by the Browser at authentication time, so that the users are forced to re-enter their credentials the next time they try to authenticate.
+
+Check in the `LoginActivity` if a boolean extra is present in the Intent at the Activity launch. This scenario triggered by the `MainActivity` dictates that the user wants to log out.
+
+```java
+// app/src/main/java/com/auth0/samples/MainActivity.java
+
+private void logout() {
+    Intent intent = new Intent(this, LoginActivity.class);
+    intent.putExtra(LoginActivity.EXTRA_CLEAR_CREDENTIALS, true);
+
+    startActivity(intent);
+    finish();
+}
+
+// app/src/main/java/com/auth0/samples/LoginActivity.java
+
+@Override
+protected void onCreate(Bundle savedInstanceState) {
+    // ...
+    if (getIntent().getBooleanExtra(EXTRA_CLEAR_CREDENTIALS, false)) {
+        logout();
+    }
+}
+
+private void logout() {
+    WebAuthProvider.logout(auth0)
+            .withScheme("demo")
+            .start(this, new VoidCallback() {
+                @Override
+                public void onSuccess(Void payload) {
+                }
+
+                @Override
+                public void onFailure(Auth0Exception error) {
+                    // Show error to user
+                }
+            });
+}
+```
+
+The logout is achieved by using the `WebAuthProvider` class. This call will open the Browser and navigate the user to the logout endpoint. If the log out is cancelled, you might want to take the user back to where they were before attempting to log out.

--- a/00-Login/TUTORIAL.md
+++ b/00-Login/TUTORIAL.md
@@ -1,4 +1,4 @@
-# Tutorial
+# Tutorial - Login
 
 _This content has been extracted from a previous version of the [Auth0 Android Quickstart](https://auth0.com/docs/quickstart/native/android) and demonstrates how to integrate Auth0 with an Android application using the [Auth0 Android](https://github.com/auth0/Auth0.Android) SDK._
 

--- a/00-Login/TUTORIAL.md
+++ b/00-Login/TUTORIAL.md
@@ -61,7 +61,7 @@ Add manifest placeholders required by the SDK. The placeholders are used interna
 
 To add the manifest placeholders, add the next line:
 
-```
+```groovy
 // app/build.gradle
 
 apply plugin: 'com.android.application'

--- a/03-Session-Handling/README.md
+++ b/03-Session-Handling/README.md
@@ -2,7 +2,7 @@
 
 This sample shows how to keep users authenticated using Auth0 refresh tokens.
 
-A step by step [Quickstart Tutorial](https://auth0.com/docs/quickstart/native/ios-swift/03-session-handling) is provided in our site. If you prefer to skip it and run the sample make sure to [setup](#setup) the project first.
+A step by step [Tutorial](./TUTORIAL.md) is provided in our site. If you prefer to skip it and run the sample make sure to [setup](#setup) the project first.
 
 ### Requirements
 

--- a/03-Session-Handling/TUTORIAL.md
+++ b/03-Session-Handling/TUTORIAL.md
@@ -1,0 +1,161 @@
+# Tutorial - Session Handling
+
+You need the `Credentials` class to handle users' credentials. The class is composed of these elements:
+
+* `accessToken`: Access Tokens used by the Auth0 API. To learn more, see the [Access Tokens](https://auth0.com/docs/tokens/access-tokens).
+* `idToken`: Identity Token that proves the identity of the user. To learn more, see the [ID Token documentation](https://auth0.com/docs/tokens/id-tokens).
+* `refreshToken`: Refresh Token that can be used to request new tokens without signing in again. To learn more, see the [Refresh Tokens](https://auth0.com/docs/tokens/refresh-tokens).
+* `tokenType`: The type of tokens issued by the server.
+* `expiresIn`: The number of seconds before the tokens expire.
+* `expiresAt`: The date when the tokens expire.
+* `scope`: The scope that was granted to a user. This information is shown only if the granted scope is different than the requested one.
+
+Tokens are objects used to prove your identity against the Auth0 APIs. Read more about them in the [tokens documentation](https://auth0.com/docs/tokens).
+
+## Before You Start
+
+> Before you continue with this tutorial, make sure that you have completed the [Login](/../00-login/TUTORIAL.md) tutorial.
+
+You will need a valid Refresh Token in the response. To do that, ask for the `offline_access` scope. Find the snippet in which you are initializing the `WebAuthProvider` class. To that snippet, add the line `withScope("openid offline_access")`.
+
+```java
+// app/src/main/java/com/auth0/samples/LoginActivity.java
+
+Auth0 auth0 = new Auth0(this);
+auth0.setOIDCConformant(true);
+
+WebAuthProvider.login(auth0)
+        .withScheme("demo")
+        .withScope("openid offline_access")
+        .withAudience(String.format("https://%s/userinfo", getString(R.string.com_auth0_domain)))
+        .start(LoginActivity.this, loginCallback);
+```
+
+## Check for Tokens when the Application Starts
+
+Before you go further with this tutorial, read the [Refresh Token documentation](https://auth0.com/docs/tokens/refresh-tokens). It is important that you remember the following:
+- Refresh Tokens must be securely saved.
+- Even though Refresh Tokens cannot expire, they can be revoked.
+- New tokens will have the same scope as was originally requested during the first authentication.
+
+You can simplify the way you handle user sessions using a Credential Manager class, which knows how to securely store, retrieve and renew credentials obtained from Auth0. This tutorial will use the `SecureCredentialsManager` class, as it encrypts the credentials before storing them in a private SharedPreferences file.
+
+Create a new instance of the Credentials Manager. When you run the application, you should check if there are any previously stored credentials. You can use these credentials to bypass the login screen:
+
+```java
+// app/src/main/java/com/auth0/samples/LoginActivity.java
+
+private SecureCredentialsManager credentialsManager;
+
+protected void onCreate(Bundle savedInstanceState) {
+    // Setup CredentialsManager
+    auth0 = new Auth0(this);
+    auth0.setOIDCConformant(true);
+    credentialsManager = new SecureCredentialsManager(this, new AuthenticationAPIClient(auth0), new SharedPreferencesStorage(this));
+
+    // Check if the activity was launched to log the user out
+    if (getIntent().getBooleanExtra(EXTRA_CLEAR_CREDENTIALS, false)) {
+        doLogout();
+        return;
+    }
+
+    if (credentialsManager.hasValidCredentials()) {
+        // Obtain the existing credentials and move to the next activity
+        showNextActivity();
+    }
+}
+```
+
+> The logic for authenticating and logging the user out is kept under the same activity. Ideally a single class should manage the handling of credentials. You can share this instance across activities as long as the Storage strategy persists the data in the same location. Check the `LoginActivity` class to understand how to achieve this in a single class.
+
+## Save the User's Credentials
+
+After a successful login response, you can store the user's credentials using the `saveCredentials` method.
+
+```java
+// app/src/main/java/com/auth0/samples/LoginActivity.java
+
+private final AuthCallback loginCallback = new AuthCallback() {
+    @Override
+    public void onFailure(@NonNull final Dialog dialog) {
+        // Show error dialog
+    }
+
+    @Override
+    public void onFailure(AuthenticationException exception) {
+        // Show error message
+    }
+
+    @Override
+    public void onSuccess(@NonNull Credentials credentials) {
+        // User successfully authenticated
+        credentialsManager.saveCredentials(credentials);
+        showNextActivity();
+    }
+};
+```
+
+> A Storage defines how data is going to be persisted in the device. The Storage implementation given to the Credentials Manager in the sample project uses a SharedPreferences file to store the user credentials in [Private mode](https://developer.android.com/reference/android/content/Context.html#MODE_PRIVATE). You can modify this behavior by implementing a custom Storage.
+
+## Recover the User's Credentials
+
+Retrieving the credentials from the Credentials Manager is an async process, as credentials may have expired and require to be refreshed. This renewing process is done automatically by the Credentials Manager as long as a valid Refresh Token is currently stored. A `CredentialsManagerException` exception will be raised if the credentials cannot be renewed.
+
+```java
+// app/src/main/java/com/auth0/samples/LoginActivity.java
+
+private void showNextActivity() {
+    credentialsManager.getCredentials(new BaseCallback<Credentials, CredentialsManagerException>() {
+        @Override
+        public void onSuccess(final Credentials credentials) {
+            // Move to the next activity
+            Intent intent = new Intent(LoginActivity.this, MainActivity.class);
+            intent.putExtra(EXTRA_ACCESS_TOKEN, credentials.getAccessToken());
+            intent.putExtra(EXTRA_ID_TOKEN, credentials.getIdToken());
+
+            startActivity(intent);
+            finish();
+        }
+
+        @Override
+        public void onFailure(CredentialsManagerException error) {
+            // Credentials could not be retrieved.
+            finish();
+        }
+    });
+}
+```
+
+> The `SecureCredentialsManager` can prompt the user for local device authentication using the configured Lock Screen (PIN, Password, Pattern, Fingerprint) before giving them the stored credentials. This behavior can be enabled calling the `SecureCredentialsManager#requireAuthentication` method when setting up the Credentials Manager. The sample has this line commented for convenience, remove the comment to try it.
+
+## Log the User Out
+
+To log the user out, it is normally enough to remove their credentials and navigate them back to the login screen. When using a Credentials Manager you do that calling `clearCredentials`. In addition, as you did previously for the login step, use the `WebAuthProvider` to remove the cookie set by the Browser at authentication time, so that the users are forced to re-enter their credentials the next time they try to authenticate. The sample combines these two strategies.
+
+```java
+// app/src/main/java/com/auth0/samples/LoginActivity.java
+
+private void doLogout() {
+    WebAuthProvider.logout(auth0)
+            .withScheme("demo")
+            .start(this, logoutCallback);
+}
+
+private VoidCallback logoutCallback = new VoidCallback() {
+    @Override
+    public void onSuccess(Void payload) {
+        credentialsManager.clearCredentials();
+    }
+
+    @Override
+    public void onFailure(Auth0Exception error) {
+        // Log out canceled, keep the user logged in
+        showNextActivity();
+    }
+};
+
+```
+
+The logout is achieved by using the `WebAuthProvider` class. This call will open the Browser and navigate the user to the logout endpoint. If the log out is cancelled, you might want to take the user back to where they were before attempting to log out. If the call succeeded you will remove the credentials from the manager instance.
+
+> If you are not using our Credentials Manager classes, you are responsible for ensuring that the user's credentials have been removed.

--- a/03-Session-Handling/TUTORIAL.md
+++ b/03-Session-Handling/TUTORIAL.md
@@ -14,7 +14,7 @@ Tokens are objects used to prove your identity against the Auth0 APIs. Read more
 
 ## Before You Start
 
-> Before you continue with this tutorial, make sure that you have completed the [Login](/../00-login/TUTORIAL.md) tutorial.
+> Before you continue with this tutorial, make sure that you have completed the [Login](/../00-Login/TUTORIAL.md) tutorial.
 
 You will need a valid Refresh Token in the response. To do that, ask for the `offline_access` scope. Find the snippet in which you are initializing the `WebAuthProvider` class. To that snippet, add the line `withScope("openid offline_access")`.
 

--- a/03-Session-Handling/TUTORIAL.md
+++ b/03-Session-Handling/TUTORIAL.md
@@ -1,5 +1,7 @@
 # Tutorial - Session Handling
 
+_This content has been extracted from a previous version of the [Auth0 Android Quickstart](https://auth0.com/docs/quickstart/native/android) and demonstrates how to integrate Auth0 with an Android application using the [Auth0 Android](https://github.com/auth0/Auth0.Android) SDK._
+
 You need the `Credentials` class to handle users' credentials. The class is composed of these elements:
 
 * `accessToken`: Access Tokens used by the Auth0 API. To learn more, see the [Access Tokens](https://auth0.com/docs/tokens/access-tokens).

--- a/03-Session-Handling/TUTORIAL.md
+++ b/03-Session-Handling/TUTORIAL.md
@@ -14,7 +14,7 @@ Tokens are objects used to prove your identity against the Auth0 APIs. Read more
 
 ## Before You Start
 
-> Before you continue with this tutorial, make sure that you have completed the [Login](/../00-Login/TUTORIAL.md) tutorial.
+> Before you continue with this tutorial, make sure that you have completed the [Login](../00-Login/TUTORIAL.md) tutorial.
 
 You will need a valid Refresh Token in the response. To do that, ask for the `offline_access` scope. Find the snippet in which you are initializing the `WebAuthProvider` class. To that snippet, add the line `withScope("openid offline_access")`.
 

--- a/04-User-Profile/TUTORIAL.md
+++ b/04-User-Profile/TUTORIAL.md
@@ -1,27 +1,10 @@
 # Tutorial - User Profile
 
----
-title: User Profile
-description: This tutorial will show you how to get and modify the user's profile data.
-seo_alias: android
-budicon: 292
-topics:
-  - quickstarts
-  - native
-  - android
-github:
-    path: 04-User-Profile
-contentType: tutorial
-useCase: quickstart
----
-
 This tutorial shows you how to get and modify the user's profile data with Auth0 in your Android apps.
 
 ## Before You Start
 
-::: note
-Before you continue with this tutorial, make sure that you have completed the [Login](/quickstart/native/android/00-login) and [Session Handling](/quickstart/native/android/03-session-handling) tutorials. To call the API applications, you need a valid Access Token.
-:::
+> Before you continue with this tutorial, make sure that you have completed the [Login](../00-Login/TUTORIAL.md) and [Session Handling](../03-Session-Handling/TUTORIAL.md) tutorials. To call the API applications, you need a valid Access Token.
 
 Before launching the login process, you need to make sure the authorization server allows you to read and edit the current user profile. To do that, ask for the `profile email read:current_user update:current_user_metadata` scopes and use the Management API audience, which happens to include the User Info audience as well. Find the snippet in which you initialize the `WebAuthProvider` class. In that snippet, find the call to `withScope` and replace its argument with `"openid profile email offline_access read:current_user update:current_user_metadata"`. Then find the call to `withAudience` and replace `"https://%s/userinfo"` with `"https://%s/api/v2/"`.
 
@@ -38,18 +21,15 @@ WebAuthProvider.login(auth0)
         .start(this, loginCallback);
 ```
 
-::: note
-Note that the Management API audience value ends in `/` in contrast to the User Info audience.
-:::
+> Note that the Management API audience value ends in `/` in contrast to the User Info audience.
 
 ## Request User Data
 
-
 To get the user's information:
-1. Use the user's Access Token to call the `userInfo` method in the `AuthenticationAPIClient` application instance.
-The profile obtained this way is OIDC-conformant. Depending on the [scopes](/scopes) you requested when logging in, the profile contains different information. The result will never contain fields outside the OIDC specification.
-2. Get the user's full profile using the [Management API](/api/management/v2#!/Users). Since fields such as [user_metadata](#additional-information) are not part of the OIDC specification you need to obtain the full profile to read them. This step is explained next:
 
+1. Use the user's Access Token to call the `userInfo` method in the `AuthenticationAPIClient` application instance.
+The profile obtained this way is OIDC-conformant. Depending on the [scopes](https://auth0.com/docs/scopes) you requested when logging in, the profile contains different information. The result will never contain fields outside the OIDC specification.
+2. Get the user's full profile using the [Management API](https://auth0.com/docs/api/management/v2#!/Users). Since fields such as `user_metadata`are not part of the OIDC specification, you need to obtain the full profile to read them. This step is explained next:
 
 Create an instance of the Users API application using the Access Token that you saved in the log in step. This Access Token can be used to authorize requests since you've requested the Management API audience and the corresponding user entity scopes in the login step. In the snippet below we obtain the token from the extras that the LoginActivity class has passed when starting this activity. The API application is used to request the user's profile data.
 
@@ -75,15 +55,12 @@ protected void onCreate(Bundle savedInstanceState) {
 }
 ```
 
-::: note
-Do not hardcode the Auth0 `domain` and `clientId` values when creating the Auth0 instance. We recommend you add them to the `strings.xml` file.
-:::
-
+> Do not hardcode the Auth0 `domain` and `clientId` values when creating the Auth0 instance. We recommend you add them to the `strings.xml` file.
 
 To get the user's profile:
 1. Use the user's Access Token to call the `userInfo` method in the `AuthenticationAPIClient` application instance.
-You get an instance of the `UserProfile` profile. The profile is OIDC-conformant. Depending on the on the [scopes](/scopes) you requested, the profile contains different information.
-2. To get the user's full profile, use the [Management API](/api/management/v2#!/Users). Use the user ID obtained in previous step to call `getProfile` on the Users API application and obtain the full user profile. Use the received data to update the layout.
+You get an instance of the `UserProfile` profile. The profile is OIDC-conformant. Depending on the on the [scopes](https://auth0.com/docs/scopes) you requested, the profile contains different information.
+2. To get the user's full profile, use the [Management API](https://auth0.com/docss/api/management/v2#!/Users). Use the user ID obtained in previous step to call `getProfile` on the Users API application and obtain the full user profile. Use the received data to update the layout.
 
 ```java
 // app/src/main/java/com/auth0/samples/activities/MainActivity.java
@@ -130,12 +107,10 @@ profile.getEmail();
 profile.getPictureURL();
 ```
 
-::: panel Modifying the UI
-You cannot modify the UI inside the callback methods as they run in a different thread. To solve this issue you can choose between three options:
-* Persist the data and then retrieve it
-* Create a task in the UI thread and run it. i.e. using the `Activity#runOnUiThread` method.
-* Create a `Handler` to post the information
-:::
+Note that you cannot modify the UI inside the callback methods as they run in a different thread. To solve this issue you can choose between three options:
+- Persist the data and then retrieve it
+- Create a task in the UI thread and run it. i.e. using the `Activity#runOnUiThread` method.
+- Create a `Handler` to post the information
 
 ### Additional information
 
@@ -149,17 +124,13 @@ The `userMetadata` map contains user profile fields that can be added from the c
 String country = (String) profile.getUserMetadata().get("country");
 ```
 
-::: note
-You can choose the key names and value types for subscripting the `user_metadata` map.
-:::
+> You can choose the key names and value types for subscripting the `user_metadata` map.
 
 #### B. App metadata
 
-The `appMetadata` map contains fields that are usually added with a [Rule](/rules) or a [Hook](/hooks). For native platforms, this information is read-only.
+The `appMetadata` map contains fields that are usually added with a [Rule](https://auth0.com/docs/rules) or a [Hook](https://auth0.com/docs/hooks). For native platforms, this information is read-only.
 
-::: note
-To learn more about metadata, see [Metadata](/users/concepts/overview-user-metadata).
-:::
+> To learn more about metadata, see [Metadata](https://auth0.com/docs/users/metadata).
 
 #### C. Extra information
 
@@ -192,7 +163,4 @@ usersClient.updateMetadata(userInfo.getId(), userMetadata).start(new BaseCallbac
 });
 ```
 
-
-::: note
-A call to `updateMetadata` will replace any previous user metadata stored in Auth0. Remember to copy the old values that you wish to maintain.
-:::
+> A call to `updateMetadata` will replace any previous user metadata stored in Auth0. Remember to copy the old values that you wish to maintain.

--- a/04-User-Profile/TUTORIAL.md
+++ b/04-User-Profile/TUTORIAL.md
@@ -1,5 +1,7 @@
 # Tutorial - User Profile
 
+_This content has been extracted from a previous version of the [Auth0 Android Quickstart](https://auth0.com/docs/quickstart/native/android) and demonstrates how to integrate Auth0 with an Android application using the [Auth0 Android](https://github.com/auth0/Auth0.Android) SDK._
+
 This tutorial shows you how to get and modify the user's profile data with Auth0 in your Android apps.
 
 ## Before You Start

--- a/04-User-Profile/TUTORIAL.md
+++ b/04-User-Profile/TUTORIAL.md
@@ -1,0 +1,198 @@
+# Tutorial - User Profile
+
+---
+title: User Profile
+description: This tutorial will show you how to get and modify the user's profile data.
+seo_alias: android
+budicon: 292
+topics:
+  - quickstarts
+  - native
+  - android
+github:
+    path: 04-User-Profile
+contentType: tutorial
+useCase: quickstart
+---
+
+This tutorial shows you how to get and modify the user's profile data with Auth0 in your Android apps.
+
+## Before You Start
+
+::: note
+Before you continue with this tutorial, make sure that you have completed the [Login](/quickstart/native/android/00-login) and [Session Handling](/quickstart/native/android/03-session-handling) tutorials. To call the API applications, you need a valid Access Token.
+:::
+
+Before launching the login process, you need to make sure the authorization server allows you to read and edit the current user profile. To do that, ask for the `profile email read:current_user update:current_user_metadata` scopes and use the Management API audience, which happens to include the User Info audience as well. Find the snippet in which you initialize the `WebAuthProvider` class. In that snippet, find the call to `withScope` and replace its argument with `"openid profile email offline_access read:current_user update:current_user_metadata"`. Then find the call to `withAudience` and replace `"https://%s/userinfo"` with `"https://%s/api/v2/"`.
+
+```java
+// app/src/main/java/com/auth0/samples/activities/LoginActivity.java
+
+Auth0 auth0 = new Auth0(this);
+auth0.setOIDCConformant(true);
+
+WebAuthProvider.login(auth0)
+        .withScheme("demo")
+        .withScope("openid profile email offline_access read:current_user update:current_user_metadata")
+        .withAudience(String.format("https://%s/api/v2/", getString(R.string.com_auth0_domain)))
+        .start(this, loginCallback);
+```
+
+::: note
+Note that the Management API audience value ends in `/` in contrast to the User Info audience.
+:::
+
+## Request User Data
+
+
+To get the user's information:
+1. Use the user's Access Token to call the `userInfo` method in the `AuthenticationAPIClient` application instance.
+The profile obtained this way is OIDC-conformant. Depending on the [scopes](/scopes) you requested when logging in, the profile contains different information. The result will never contain fields outside the OIDC specification.
+2. Get the user's full profile using the [Management API](/api/management/v2#!/Users). Since fields such as [user_metadata](#additional-information) are not part of the OIDC specification you need to obtain the full profile to read them. This step is explained next:
+
+
+Create an instance of the Users API application using the Access Token that you saved in the log in step. This Access Token can be used to authorize requests since you've requested the Management API audience and the corresponding user entity scopes in the login step. In the snippet below we obtain the token from the extras that the LoginActivity class has passed when starting this activity. The API application is used to request the user's profile data.
+
+Create now an instance of the Authentication API application. This time is used to call the userinfo endpoint and retrieve the ID of the user to whom the token was issued.
+
+```java
+// app/src/main/java/com/auth0/samples/activities/MainActivity.java
+
+private UsersAPIClient usersClient;
+private AuthenticationAPIClient authenticationAPIClient;
+
+@Override
+protected void onCreate(Bundle savedInstanceState) {
+    // ...
+    Auth0 auth0 = new Auth0(this);
+    auth0.setOIDCConformant(true);
+
+    String accessToken = getIntent().getStringExtra(LoginActivity.EXTRA_ACCESS_TOKEN);
+    usersClient = new UsersAPIClient(auth0, accessToken);
+    authenticationAPIClient = new AuthenticationAPIClient(auth0);
+
+    getProfile(accessToken);
+}
+```
+
+::: note
+Do not hardcode the Auth0 `domain` and `clientId` values when creating the Auth0 instance. We recommend you add them to the `strings.xml` file.
+:::
+
+
+To get the user's profile:
+1. Use the user's Access Token to call the `userInfo` method in the `AuthenticationAPIClient` application instance.
+You get an instance of the `UserProfile` profile. The profile is OIDC-conformant. Depending on the on the [scopes](/scopes) you requested, the profile contains different information.
+2. To get the user's full profile, use the [Management API](/api/management/v2#!/Users). Use the user ID obtained in previous step to call `getProfile` on the Users API application and obtain the full user profile. Use the received data to update the layout.
+
+```java
+// app/src/main/java/com/auth0/samples/activities/MainActivity.java
+
+private void getProfile(String accessToken) {
+    authenticationAPIClient.userInfo(accessToken)
+            .start(new BaseCallback<UserProfile, AuthenticationException>() {
+                @Override
+                public void onSuccess(UserProfile userinfo) {
+                    usersClient.getProfile(userinfo.getId())
+                        .start(new BaseCallback<UserProfile, ManagementException>() {
+                            @Override
+                            public void onSuccess(UserProfile profile) {
+                                // Display the user profile
+                            }
+
+                            @Override
+                            public void onFailure(ManagementException error) {
+                                // Show error
+                            }
+                        });
+                }
+
+                @Override
+                public void onFailure(AuthenticationException error) {
+                    // Show error
+                }
+            });
+}
+```
+
+## Access the Data Inside the Received Profile
+
+### Default information
+
+At this point, you already have access to the full version of the `UserProfile` instance.
+You can use this data wherever you need it.
+
+Some examples are:
+
+```java
+profile.getName();
+profile.getEmail();
+profile.getPictureURL();
+```
+
+::: panel Modifying the UI
+You cannot modify the UI inside the callback methods as they run in a different thread. To solve this issue you can choose between three options:
+* Persist the data and then retrieve it
+* Create a task in the UI thread and run it. i.e. using the `Activity#runOnUiThread` method.
+* Create a `Handler` to post the information
+:::
+
+### Additional information
+
+You can handle additional information within any of the following maps:
+
+#### A. User metadata
+
+The `userMetadata` map contains user profile fields that can be added from the client-side (such as when a user edits their profile). You can access this information in the following way:
+
+```java
+String country = (String) profile.getUserMetadata().get("country");
+```
+
+::: note
+You can choose the key names and value types for subscripting the `user_metadata` map.
+:::
+
+#### B. App metadata
+
+The `appMetadata` map contains fields that are usually added with a [Rule](/rules) or a [Hook](/hooks). For native platforms, this information is read-only.
+
+::: note
+To learn more about metadata, see [Metadata](/users/concepts/overview-user-metadata).
+:::
+
+#### C. Extra information
+
+The `extraInfo` map contains additional values that are stored in Auth0 but not mapped to a `UserProfile` getter method. For native platforms, this information is read-only.
+
+## Update the User's Profile
+
+You can only update the user metadata. To do this, create a `Map<String, Object>` object and add the information you want to store.
+
+```java
+Map<String, Object> userMetadata = new HashMap<>();
+userMetadata.put("country", "USA");
+```
+
+Update the information with the Users API application created before:
+
+```java
+// app/src/main/java/com/auth0/samples/activities/MainActivity.java
+
+usersClient.updateMetadata(userInfo.getId(), userMetadata).start(new BaseCallback<UserProfile, ManagementException>() {
+    @Override
+    public void onSuccess(UserProfile profile) {
+        // You can react to this, and show the information to the user.
+    }
+
+    @Override
+    public void onFailure(ManagementException error) {
+        // Show error
+    }
+});
+```
+
+
+::: note
+A call to `updateMetadata` will replace any previous user metadata stored in Auth0. Remember to copy the old values that you wish to maintain.
+:::

--- a/05-Linking-Accounts/README.md
+++ b/05-Linking-Accounts/README.md
@@ -2,7 +2,7 @@
 
 This sample shows how to merge two auth0 users' accounts into a single account.
 
-A step by step [Quickstart Tutorial](https://auth0.com/docs/quickstart/native/android/05-linking-accounts) is provided in our site. If you prefer to skip it and run the sample make sure to [setup](#setup) the project first.
+A step by step [Tutorial](./TUTORIAL.md) is provided in our site. If you prefer to skip it and run the sample make sure to [setup](#setup) the project first.
 
 ### Requirements
 

--- a/05-Linking-Accounts/TUTORIAL.md
+++ b/05-Linking-Accounts/TUTORIAL.md
@@ -1,35 +1,20 @@
 # Tutorial - Linking Accounts
 
----
-title: Linking Accounts
-description: This tutorial will show you how to link two different accounts for the same user.
-seo_alias: android
-budicon: 345
-topics:
-  - quickstarts
-  - native
-  - android
-github:
-    path: 05-Linking-Accounts
-contentType: tutorial
-useCase: quickstart
----
-
 ## Before You Start
 
 Before you continue with this tutorial, make sure that you have completed the previous tutorials. This tutorial assumes that:
 * You have integrated [Auth0](https://github.com/auth0/Auth0.Android) as a dependency in your project.
-* You are familiar with the `WebAuthProvider` class. To learn more, see the [Login](/quickstart/native/android/00-login) and the [Session Handling](/quickstart/native/android/03-session-handling) tutorials.
-* You are familiar with the concepts of `userId`, `accessToken` and `idToken`. You can find info about them in the [Session Handling](/quickstart/native/android/03-session-handling) and the [User Profile](/quickstart/native/android/04-user-profile) tutorials.
+* You are familiar with the `WebAuthProvider` class. To learn more, see the [Login](../00-Login/TUTORIAL.md) and the [Session Handling](../03-Session-Handling/TUTORIAL.md) tutorials.
+* You are familiar with the concepts of `userId`, `accessToken` and `idToken`. You can find info about them in the [Session Handling](../03-Session-Handling/TUTORIAL.md) and the [User Profile](../04-User-Profile/TUTORIAL.md) tutorials.
 
-We recommend that you read the [Linking Accounts](/users/concepts/overview-user-account-linking) documentation to understand the process of linking accounts.
+We recommend that you read the [Linking Accounts](https://auth0.com/docs/users/user-account-linking) documentation to understand the process of linking accounts.
 
 ## API scopes on Authentication
 
-As seen previously in the [User Profile](/quickstart/native/android/04-user-profile) tutorial, you need to request the Management API audience and the corresponding scopes to be able to read the full user profile and edit their identities, since they are not part of the OIDC specification. Each identity in the user profile represents details from the authentication provider used to log in. e.g. the user's Facebook account details.
+As seen previously in the [User Profile](../04-User-Profile/TUTORIAL.md) tutorial, you need to request the Management API audience and the corresponding scopes to be able to read the full user profile and edit their identities, since they are not part of the OIDC specification. Each identity in the user profile represents details from the authentication provider used to log in. e.g. the user's Facebook account details.
 
 ```java
-// app/src/main/java/com/auth0/samples/activities/LoginActivity.java
+// app/src/main/java/com/auth0/samples/activities/LoginActivity.java◊
 
 Auth0 auth0 = new Auth0(this);
 auth0.setOIDCConformant(true);
@@ -41,16 +26,13 @@ WebAuthProvider.login(auth0)
         .start(this, callback);
 ```
 
-::: note
-Note that the Management API audience value ends in `/` in contrast to the User Info audience.
-:::
-
+> Note that the Management API audience value ends in `/` in contrast to the User Info audience.
 
 ## Enter Account Credentials
 
 Your users may want to link their other accounts to the account they are logged in to.
 
-To achieve this, you need to store the user ID for the logged user in the Intent, along with the ID Token and Access Token provided by the LoginActivity at launch, which are already available in the intent extras.
+To achieve this, you need to store the user ID for the logged user in the Intent, along with the ID Token and Access Token provided by the `LoginActivity` at launch, which are already available in the intent extras.
 
 ```java
 // app/src/main/java/com/auth0/samples/activities/MainActivity.java
@@ -162,10 +144,7 @@ private final AuthCallback loginCallback = new AuthCallback() {
 };
 ```
 
-::: note
-Make sure to handle the callback's failure calls as well
-:::
-
+> Make sure to handle the callback's failure calls as well.
 
 ## Link the Accounts
 
@@ -217,16 +196,14 @@ private void fetchProfile() {
 }
 ```
 
-::: note
-For more information, check the [UserIdentity.java class documentation](https://github.com/auth0/Auth0.Android/blob/master/auth0/src/main/java/com/auth0/android/result/UserIdentity.java).
-:::
+> For more information, check the [UserIdentity.java class documentation](https://github.com/auth0/Auth0.Android/blob/v1/auth0/src/main/java/com/auth0/android/result/UserIdentity.java).
 
 ## Unlink the Accounts
 
 To unlink the accounts, you need to specify the following:
-* user ID for the main account
-* user ID for the linked account
-* the provider name for the linked account
+- user ID for the main account
+- user ID for the linked account
+- the provider name for the linked account
 
 To instantiate the `UsersAPIClient` client, use the Access Token for the main account like before.
 

--- a/05-Linking-Accounts/TUTORIAL.md
+++ b/05-Linking-Accounts/TUTORIAL.md
@@ -3,9 +3,9 @@
 ## Before You Start
 
 Before you continue with this tutorial, make sure that you have completed the previous tutorials. This tutorial assumes that:
-* You have integrated [Auth0](https://github.com/auth0/Auth0.Android) as a dependency in your project.
-* You are familiar with the `WebAuthProvider` class. To learn more, see the [Login](../00-Login/TUTORIAL.md) and the [Session Handling](../03-Session-Handling/TUTORIAL.md) tutorials.
-* You are familiar with the concepts of `userId`, `accessToken` and `idToken`. You can find info about them in the [Session Handling](../03-Session-Handling/TUTORIAL.md) and the [User Profile](../04-User-Profile/TUTORIAL.md) tutorials.
+- You have integrated [Auth0](https://github.com/auth0/Auth0.Android) as a dependency in your project.
+- You are familiar with the `WebAuthProvider` class. To learn more, see the [Login](../00-Login/TUTORIAL.md) and the [Session Handling](../03-Session-Handling/TUTORIAL.md) tutorials.
+- You are familiar with the concepts of `userId`, `accessToken` and `idToken`. You can find info about them in the [Session Handling](../03-Session-Handling/TUTORIAL.md) and the [User Profile](../04-User-Profile/TUTORIAL.md) tutorials.
 
 We recommend that you read the [Linking Accounts](https://auth0.com/docs/users/user-account-linking) documentation to understand the process of linking accounts.
 

--- a/05-Linking-Accounts/TUTORIAL.md
+++ b/05-Linking-Accounts/TUTORIAL.md
@@ -1,0 +1,250 @@
+# Tutorial - Linking Accounts
+
+---
+title: Linking Accounts
+description: This tutorial will show you how to link two different accounts for the same user.
+seo_alias: android
+budicon: 345
+topics:
+  - quickstarts
+  - native
+  - android
+github:
+    path: 05-Linking-Accounts
+contentType: tutorial
+useCase: quickstart
+---
+
+## Before You Start
+
+Before you continue with this tutorial, make sure that you have completed the previous tutorials. This tutorial assumes that:
+* You have integrated [Auth0](https://github.com/auth0/Auth0.Android) as a dependency in your project.
+* You are familiar with the `WebAuthProvider` class. To learn more, see the [Login](/quickstart/native/android/00-login) and the [Session Handling](/quickstart/native/android/03-session-handling) tutorials.
+* You are familiar with the concepts of `userId`, `accessToken` and `idToken`. You can find info about them in the [Session Handling](/quickstart/native/android/03-session-handling) and the [User Profile](/quickstart/native/android/04-user-profile) tutorials.
+
+We recommend that you read the [Linking Accounts](/users/concepts/overview-user-account-linking) documentation to understand the process of linking accounts.
+
+## API scopes on Authentication
+
+As seen previously in the [User Profile](/quickstart/native/android/04-user-profile) tutorial, you need to request the Management API audience and the corresponding scopes to be able to read the full user profile and edit their identities, since they are not part of the OIDC specification. Each identity in the user profile represents details from the authentication provider used to log in. e.g. the user's Facebook account details.
+
+```java
+// app/src/main/java/com/auth0/samples/activities/LoginActivity.java
+
+Auth0 auth0 = new Auth0(this);
+auth0.setOIDCConformant(true);
+
+WebAuthProvider.login(auth0)
+        .withScheme("demo")
+        .withScope("openid profile email offline_access read:current_user update:current_user_identities")
+        .withAudience(String.format("https://%s/api/v2/", getString(R.string.com_auth0_domain)))
+        .start(this, callback);
+```
+
+::: note
+Note that the Management API audience value ends in `/` in contrast to the User Info audience.
+:::
+
+
+## Enter Account Credentials
+
+Your users may want to link their other accounts to the account they are logged in to.
+
+To achieve this, you need to store the user ID for the logged user in the Intent, along with the ID Token and Access Token provided by the LoginActivity at launch, which are already available in the intent extras.
+
+```java
+// app/src/main/java/com/auth0/samples/activities/MainActivity.java
+
+private void linkAccount() {
+    Intent linkAccounts = new Intent(this, LoginActivity.class);
+    linkAccounts.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
+    linkAccounts.putExtras(getIntent().getExtras());
+    linkAccounts.putExtra(LoginActivity.EXTRA_LINK_ACCOUNTS, true);
+    linkAccounts.putExtra(LoginActivity.EXTRA_PRIMARY_USER_ID, userProfile.getId());
+
+    startActivity(linkAccounts);
+}
+```
+
+Obtain the stored values in `LoginActivity`.
+
+First in `onCreate`, check if a new account linking was requested. Check as well if a previous `savedInstanceState` exists and contains the "logging in" state. This flag is set when the web authentication is launched and must be correctly handled to avoid state loss.
+
+```java
+// app/src/main/java/com/auth0/samples/activities/LoginActivity.java
+
+private boolean linkSession;
+private boolean logginIn;
+
+@Override
+protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Setup the UI
+    setContentView(R.layout.activity_login);
+    Button loginButton = findViewById(R.id.loginButton);
+    loginButton.setOnClickListener(new View.OnClickListener() {
+        @Override
+        public void onClick(View v) {
+            doLogin();
+        }
+    });
+
+    // Setup CredentialsManager
+    auth0 = new Auth0(this);
+    auth0.setOIDCConformant(true);
+    credentialsManager = new SecureCredentialsManager(this, new AuthenticationAPIClient(auth0), new SharedPreferencesStorage(this));
+
+    // Optional - Uncomment the next line to use:
+    // Require device authentication before obtaining the credentials
+    // credentialsManager.requireAuthentication(this, CODE_DEVICE_AUTHENTICATION, getString(R.string.request_credentials_title), null);
+
+    // Check if the activity was launched to log the user out
+    if (getIntent().getBooleanExtra(EXTRA_CLEAR_CREDENTIALS, false)) {
+        doLogout();
+        return;
+    }
+
+    linkSessions = getIntent().getBooleanExtra(EXTRA_LINK_ACCOUNTS, false);
+    loggingIn = savedInstanceState != null && savedInstanceState.getBoolean(EXTRA_LOG_IN_IN_PROGRESS, false);
+
+    if (!linkSessions && credentialsManager.hasValidCredentials()) {
+        // Obtain the existing credentials and move to the next activity
+        showNextActivity();
+        return;
+    }
+
+    // Check if an account linking was requested
+    if (linkSessions && !loggingIn) {
+        loginButton.setText(R.string.link_account);
+        // Auto log in but allow to retry if authentication is cancelled
+        doLogin();
+    }
+}
+
+@Override
+protected void onSaveInstanceState(Bundle outState) {
+    outState.putBoolean(EXTRA_LOG_IN_IN_PROGRESS, loggingIn);
+    super.onSaveInstanceState(outState);
+}
+```
+
+In the login response, based on the boolean flag set in the first step, decide if you need to show the `MainActivity` screen, or continue to link the accounts.
+
+```java
+// app/src/main/java/com/auth0/samples/activities/LoginActivity.java
+
+private final AuthCallback loginCallback = new AuthCallback() {
+    @Override
+    public void onFailure(@NonNull final Dialog dialog) {
+        // Show error message
+        // If currently linking accounts, finish.
+    }
+
+    @Override
+    public void onFailure(AuthenticationException exception) {
+        // Show error message
+        // If currently linking accounts, finish.
+    }
+
+    @Override
+    public void onSuccess(@NonNull Credentials credentials) {
+        if (linkSessions) {
+            // Link the accounts
+            performLink(credentials.getIdToken());
+            return;
+        }
+
+        // Store the credentials and move to the next activity
+        credentialsManager.saveCredentials(credentials);
+        showNextActivity(credentials);
+    }
+};
+```
+
+::: note
+Make sure to handle the callback's failure calls as well
+:::
+
+
+## Link the Accounts
+
+Now, you can link the accounts. To do this, you need the logged-in user's ID and Access Token, and the ID Token for the secondary account received in the last login response.
+
+```java
+// app/src/main/java/com/auth0/samples/activities/LoginActivity.java
+
+private void performLink(final String secondaryIdToken) {
+    UsersAPIClient client = new UsersAPIClient(auth0, getIntent().getExtras().getString(EXTRA_ACCESS_TOKEN));
+    String primaryUserId = getIntent().getExtras().getString(EXTRA_PRIMARY_USER_ID);
+
+    client.link(primaryUserId, secondaryIdToken)
+            .start(new BaseCallback<List<UserIdentity>, ManagementException>() {
+                @Override
+                public void onSuccess(List<UserIdentity> userIdentities) {
+                    // Accounts linked
+                }
+
+                @Override
+                public void onFailure(ManagementException error) {
+                    // Linking failed
+                }
+            });
+}
+```
+
+## Retrieve the Linked Accounts
+
+The updated list of identities is returned in the `link` method response. Alternatively, obtain the user's full profile, use the user's ID to call the `getProfile` method in the `UsersAPIClient` class. The profile includes the linked accounts as the `UserIdentity` array.
+
+```java
+// app/src/main/java/com/auth0/samples/activities/MainActivity.java
+
+private void fetchProfile() {
+    // ...
+    usersClient.getProfile(userInfo.getId())
+            .start(new BaseCallback<UserProfile, ManagementException>() {
+                @Override
+                public void onSuccess(UserProfile fullProfile) {
+                    // Display the updated user profile
+                }
+
+                @Override
+                public void onFailure(ManagementException error) {
+                    // Show error
+                }
+            });
+}
+```
+
+::: note
+For more information, check the [UserIdentity.java class documentation](https://github.com/auth0/Auth0.Android/blob/master/auth0/src/main/java/com/auth0/android/result/UserIdentity.java).
+:::
+
+## Unlink the Accounts
+
+To unlink the accounts, you need to specify the following:
+* user ID for the main account
+* user ID for the linked account
+* the provider name for the linked account
+
+To instantiate the `UsersAPIClient` client, use the Access Token for the main account like before.
+
+```java
+// app/src/main/java/com/auth0/samples/activities/MainActivity.java
+
+private void unlink(UserIdentity secondaryAccountIdentity) {
+    usersClient.unlink(userProfile.getId(), secondaryAccountIdentity.getId(), secondaryAccountIdentity.getProvider())
+            .start(new BaseCallback<List<UserIdentity>, ManagementException>() {
+                @Override
+                public void onSuccess(List<UserIdentity> userIdentities) {
+                    // Accounts unlinked
+                }
+
+                @Override
+                public void onFailure(ManagementException error) {
+                    // Accounts unlink failed
+                }
+            });
+}
+```

--- a/05-Linking-Accounts/TUTORIAL.md
+++ b/05-Linking-Accounts/TUTORIAL.md
@@ -1,5 +1,7 @@
 # Tutorial - Linking Accounts
 
+_This content has been extracted from a previous version of the [Auth0 Android Quickstart](https://auth0.com/docs/quickstart/native/android) and demonstrates how to integrate Auth0 with an Android application using the [Auth0 Android](https://github.com/auth0/Auth0.Android) SDK._
+
 ## Before You Start
 
 Before you continue with this tutorial, make sure that you have completed the previous tutorials. This tutorial assumes that:

--- a/06-Calling-APIs/README.md
+++ b/06-Calling-APIs/README.md
@@ -2,7 +2,7 @@
 
 This sample shows how to perform authentication against your API after logging in a user and obtaining its token.
 
-A step by step [Quickstart Tutorial](https://auth0.com/docs/quickstart/native/android/06-calling-apis) is provided in our site. If you prefer to skip it and run the sample make sure to [setup](#setup) the project first.
+A step by step [Tutorial](./TUTORIAL.md) is provided in our site. If you prefer to skip it and run the sample make sure to [setup](#setup) the project first.
 
 ### Requirements
 

--- a/06-Calling-APIs/TUTORIAL.md
+++ b/06-Calling-APIs/TUTORIAL.md
@@ -1,5 +1,7 @@
 # Tutorial - Calling APIs
 
+_This content has been extracted from a previous version of the [Auth0 Android Quickstart](https://auth0.com/docs/quickstart/native/android) and demonstrates how to integrate Auth0 with an Android application using the [Auth0 Android](https://github.com/auth0/Auth0.Android) SDK._
+
 You may want to restrict access to your API resources, so that only authenticated users with sufficient privileges can access them. Auth0 lets you manage access to these resources using [API Authorization](https://auth0.com/docs/authorization).
 
 This tutorial shows you how to access protected resources in your API.

--- a/06-Calling-APIs/TUTORIAL.md
+++ b/06-Calling-APIs/TUTORIAL.md
@@ -1,39 +1,32 @@
 # Tutorial - Calling APIs
 
----
-title: Calling APIs
-description: This tutorial will show you how to use Access Tokens to make authenticated API calls.
-seo_alias: android
-budicon: 546
-topics:
-  - quickstarts
-  - native
-  - android
-github:
-    path: 06-Calling-APIs
-contentType: tutorial
-useCase: quickstart
----
-
-You may want to restrict access to your API resources, so that only authenticated users with sufficient privileges can access them. Auth0 lets you manage access to these resources using [API Authorization](/api-auth).
+You may want to restrict access to your API resources, so that only authenticated users with sufficient privileges can access them. Auth0 lets you manage access to these resources using [API Authorization](https://auth0.com/docs/authorization).
 
 This tutorial shows you how to access protected resources in your API.
 
 ## Before You Start
 
 Before you continue with this tutorial, make sure that you have completed the previous tutorials. This tutorial assumes that:
-* You have completed the [Session Handling](/quickstart/native/android/03-session-handling) tutorial and you know how to handle the `Credentials` object.
-* You have set up a backend application as API. To learn how to do it, follow one of the [backend tutorials](/quickstart/backend).
+- You have completed the [Session Handling](../03-Session-Handling/TUTORIAL.md) tutorial and you know how to handle the `Credentials` object.
+- You have set up a backend application as API. To learn how to do it, follow one of the [backend tutorials](https://auth0.com/docs/quickstart/backend).
 
+## Create an Auth0 API
 
-<%= include('../_includes/_calling_api_create_api') %>
+In the APIs section of the Auth0 dashboard, click **Create API**. Provide a name and an identifier for your API.
+You will use the identifier later when you're preparing the Web Authentication.
+For **Signing Algorithm**, select **RS256**.
 
-<%= include('../_includes/_calling_api_create_scope') %>__
+## Add a Scope
 
+By default, the Access Token does not contain any authorization information. To limit access to your resources based on authorization, you must use scopes. Read more about scopes in the [scopes documentation](https://auth0.com/docs/scopes).
+
+In the Auth0 dashboard, in the APIs section, click **Scopes**. Add any scopes you need to limit access to your API resources.
+
+> You can give any names to your scopes. A common pattern is `<action>:<resource>`. The example below uses the name `read:messages` for a scope.
 
 ## Get the User's Access Token
 
-To retrieve an Access Token that is authorized to access your API, you need to specify the API Identifier you created in the Auth0 dashboard before. At the top of the class add the constants for accessing the API: API_URL and API_IDENTIFIER
+To retrieve an Access Token that is authorized to access your API, you need to specify the API Identifier you created in the Auth0 dashboard before. At the top of the class add the constants for accessing the API: `API_UR`L and `API_IDENTIFIER`
 
 ```java
 // app/src/main/java/com/auth0/samples/LoginActivity.java
@@ -67,23 +60,17 @@ private void login() {
 }
 ```
 
-::: note
-For instructions on how to authenticate a user, see the [Login](/quickstart/native/android/00-login) tutorial.
-:::
+> For instructions on how to authenticate a user, see the [Login](../00-Login/TUTORIAL.md) tutorial.
 
 ## Attach the Token
 
 To give the authenticated user access to secured resources in your API, include the user's Access Token in the requests you send to the API.
 
-::: note
-In this example, we use the [OkHttp](https://github.com/square/okhttp) library.
-:::
+> In this example, we use the [OkHttp](https://github.com/square/okhttp) library.
 
 Create an instance of the `OkHttpClient` client and a new `Request`. Use the provided builder to customize the Http method, the URL and the headers in the request. Set the **Authorization** header with the token type and the user's Access Token. In the sample project an `accessToken` field is set upon authentication success with the `credentials.getAccessToken()` value.
 
-::: note
-Depending on the standards in your API, you configure the authorization header differently. The code below is just an example.
-:::
+> Depending on the standards in your API, you configure the authorization header differently. The code below is just an example.
 
 
 ```java

--- a/06-Calling-APIs/TUTORIAL.md
+++ b/06-Calling-APIs/TUTORIAL.md
@@ -1,0 +1,124 @@
+# Tutorial - Calling APIs
+
+---
+title: Calling APIs
+description: This tutorial will show you how to use Access Tokens to make authenticated API calls.
+seo_alias: android
+budicon: 546
+topics:
+  - quickstarts
+  - native
+  - android
+github:
+    path: 06-Calling-APIs
+contentType: tutorial
+useCase: quickstart
+---
+
+You may want to restrict access to your API resources, so that only authenticated users with sufficient privileges can access them. Auth0 lets you manage access to these resources using [API Authorization](/api-auth).
+
+This tutorial shows you how to access protected resources in your API.
+
+## Before You Start
+
+Before you continue with this tutorial, make sure that you have completed the previous tutorials. This tutorial assumes that:
+* You have completed the [Session Handling](/quickstart/native/android/03-session-handling) tutorial and you know how to handle the `Credentials` object.
+* You have set up a backend application as API. To learn how to do it, follow one of the [backend tutorials](/quickstart/backend).
+
+
+<%= include('../_includes/_calling_api_create_api') %>
+
+<%= include('../_includes/_calling_api_create_scope') %>__
+
+
+## Get the User's Access Token
+
+To retrieve an Access Token that is authorized to access your API, you need to specify the API Identifier you created in the Auth0 dashboard before. At the top of the class add the constants for accessing the API: API_URL and API_IDENTIFIER
+
+```java
+// app/src/main/java/com/auth0/samples/LoginActivity.java
+
+private static final String API_URL = "localhost:8080/secure";
+private static final String API_IDENTIFIER = "https://api.mysite.com";
+
+private void login() {
+    Auth0 auth0 = new Auth0(this);
+    auth0.setOIDCConformant(true);
+
+    WebAuthProvider.login(auth0)
+            .withScheme("demo")
+            .withAudience(API_IDENTIFIER)
+            .start(LoginActivity.this, new AuthCallback() {
+                @Override
+                public void onFailure(@NonNull Dialog dialog) {
+                    // Show error Dialog to user
+                }
+
+                @Override
+                public void onFailure(AuthenticationException exception) {
+                    // Show error to user
+                }
+
+                @Override
+                public void onSuccess(@NonNull Credentials credentials) {
+                    // Verify tokens and Store credentials
+                }
+        });
+}
+```
+
+::: note
+For instructions on how to authenticate a user, see the [Login](/quickstart/native/android/00-login) tutorial.
+:::
+
+## Attach the Token
+
+To give the authenticated user access to secured resources in your API, include the user's Access Token in the requests you send to the API.
+
+::: note
+In this example, we use the [OkHttp](https://github.com/square/okhttp) library.
+:::
+
+Create an instance of the `OkHttpClient` client and a new `Request`. Use the provided builder to customize the Http method, the URL and the headers in the request. Set the **Authorization** header with the token type and the user's Access Token. In the sample project an `accessToken` field is set upon authentication success with the `credentials.getAccessToken()` value.
+
+::: note
+Depending on the standards in your API, you configure the authorization header differently. The code below is just an example.
+:::
+
+
+```java
+// app/src/main/java/com/auth0/samples/MainActivity.java
+
+OkHttpClient client = new OkHttpClient();
+Request request = new Request.Builder()
+        .get()
+        .url(API_URL)
+        .addHeader("Authorization", "Bearer " + accessToken)
+        .build();
+```
+
+## Send the Request
+
+Tell the client to create a new `Call` with the request you created. Call the `enqueue` function to execute the request asynchronously.
+
+```java
+// app/src/main/java/com/auth0/samples/MainActivity.java
+
+client.newCall(request).enqueue(new Callback() {
+    @Override
+    public void onFailure(Request request, final IOException e) {
+        // Show error
+    }
+
+    @Override
+    public void onResponse(final Response response) throws IOException {
+        if (response.isSuccessful()) {
+            // API call success
+        } else {
+            // API call failed. Check http error code and message
+        }
+    }
+});
+```
+
+You need to configure your backend application to protect your API endpoints with the key for your Auth0 application, API identifier and API scopes. In this example, you can use the user's Access Token issued by Auth0 to call your own APIs.

--- a/07-Authorization/README.md
+++ b/07-Authorization/README.md
@@ -2,7 +2,7 @@
 
 This sample shows how to use the token to perform local user authorization.
 
-A step by step [Quickstart Tutorial](https://auth0.com/docs/quickstart/native/android/07-authorization) is provided in our site. If you prefer to skip it and run the sample make sure to [setup](#setup) the project first.
+A step by step [Tutorial](./TUTORIAL.md) is provided in our site. If you prefer to skip it and run the sample make sure to [setup](#setup) the project first.
 
 ### Requirements
 

--- a/07-Authorization/TUTORIAL.md
+++ b/07-Authorization/TUTORIAL.md
@@ -1,0 +1,82 @@
+# Tutorial - Authorization
+
+---
+title: Authorization
+description: This tutorial will show you how to use the Auth0 authentication API in your Android project to create a custom login screen.
+seo_alias: android
+budicon: 500
+topics:
+  - quickstarts
+  - native
+  - android
+github:
+  path: 07-Authorization
+contentType: tutorial
+useCase: quickstart
+---
+
+This tutorial shows you how to use Auth0 to create access roles for your users. With access roles, you can authorize or deny access to your content to different users based on the level of access they have.
+
+## Before You Start
+
+::: note
+Be sure that you have completed the [Login](/quickstart/native/android/00-login) quickstart.
+:::
+
+Create a [Rule](https://auth0.com/docs/rules) that assigns the users either an `admin` role, or a simple `user` role. Go to the [new rule page](${manage_url}/#/rules/new) and select the **Set Roles To A User** template, under **Access Control**. Edit the following lines from the default script to match the conditions that fit your needs:
+
+```js
+const addRolesToUser = function (user) {
+    const endsWith = '@example.com';
+
+    if (user.email && (user.email.substring(user.email.length - endsWith.length, user.email.length) === endsWith)) {
+      return ['admin'];
+    }
+    return ['user'];
+};
+```
+
+The default rules for assigning access roles are:
+* If the user's email contains `@example.com`, the user gets the admin role.
+* If the email contains anything else, the user gets the regular user role.
+
+::: note
+The rule can be customized to grant the user different roles other than the ones explained here, depending on the conditions required in a project. There is a restriction on the name of the claims added to the ID Token which must be [namespaced](/tokens/guides/create-namespaced-custom-claims). Read [this article](/rules/current#hello-world) for more context about Rules.
+:::
+
+
+## Test the Rule in Your Project
+
+Once the user credentials had been obtained (as explained in the [Login](/quickstart/native/android/00-login) tutorial), save them to access them at any time.
+
+The claims added to the ID Token via a Rule are included in the userinfo endpoint response. Use the Access Token to call this endpoint and obtain the user roles.
+
+```java
+// app/src/main/java/com/auth0/samples/activities/MainActivity.java
+
+authenticationClient.userInfo(accessToken)
+      .start(new BaseCallback<UserProfile, AuthenticationException>() {
+          @Override
+          public void onSuccess(UserProfile userInfo) {
+              // Obtain the claim from the "extra info" of the user info
+              List<String> roles = userInfo.getExtraInfo().containsKey("https://example.com/roles") ?
+                  (List<String>) userInfo.getExtraInfo().get("https://example.com/roles") :
+                  Collections.<String>emptyList();
+
+              if (!roles.contains("admin")) {
+                  // User is not authorized
+              } else {
+                  // User is authorized
+              }
+          }
+
+          @Override
+          public void onFailure(AuthenticationException error) {
+              // Show error
+          }
+      });
+```
+
+## Restrict Content Based On Access Level
+
+Roles can be used to distinguish user permissions within an app, authorizing or denying access to a certain feature. The sample project illustrates this by allowing users with the `admin` role to access the "Settings Activity".

--- a/07-Authorization/TUTORIAL.md
+++ b/07-Authorization/TUTORIAL.md
@@ -1,29 +1,12 @@
 # Tutorial - Authorization
 
----
-title: Authorization
-description: This tutorial will show you how to use the Auth0 authentication API in your Android project to create a custom login screen.
-seo_alias: android
-budicon: 500
-topics:
-  - quickstarts
-  - native
-  - android
-github:
-  path: 07-Authorization
-contentType: tutorial
-useCase: quickstart
----
-
 This tutorial shows you how to use Auth0 to create access roles for your users. With access roles, you can authorize or deny access to your content to different users based on the level of access they have.
 
 ## Before You Start
 
-::: note
-Be sure that you have completed the [Login](/quickstart/native/android/00-login) quickstart.
-:::
+> Be sure that you have completed the [Login](../00-Login/TUTORIAL.md) tutorial.
 
-Create a [Rule](https://auth0.com/docs/rules) that assigns the users either an `admin` role, or a simple `user` role. Go to the [new rule page](${manage_url}/#/rules/new) and select the **Set Roles To A User** template, under **Access Control**. Edit the following lines from the default script to match the conditions that fit your needs:
+Create a [Rule](https://auth0.com/docs/rules) that assigns the users either an `admin` role, or a simple `user` role. Go to the New Rule page and select the **Set Roles To A User** template, under **Access Control**. Edit the following lines from the default script to match the conditions that fit your needs:
 
 ```js
 const addRolesToUser = function (user) {
@@ -37,17 +20,14 @@ const addRolesToUser = function (user) {
 ```
 
 The default rules for assigning access roles are:
-* If the user's email contains `@example.com`, the user gets the admin role.
-* If the email contains anything else, the user gets the regular user role.
+- If the user's email contains `@example.com`, the user gets the admin role.
+- If the email contains anything else, the user gets the regular user role.
 
-::: note
-The rule can be customized to grant the user different roles other than the ones explained here, depending on the conditions required in a project. There is a restriction on the name of the claims added to the ID Token which must be [namespaced](/tokens/guides/create-namespaced-custom-claims). Read [this article](/rules/current#hello-world) for more context about Rules.
-:::
-
+> The rule can be customized to grant the user different roles other than the ones explained here, depending on the conditions required in a project. There is a restriction on the name of the claims added to the ID Token which must be [namespaced](https://auth0.com/docs/tokens/create-namespaced-custom-claims). Read [this article](https://auth0.com/docs/rules) for more context about Rules.
 
 ## Test the Rule in Your Project
 
-Once the user credentials had been obtained (as explained in the [Login](/quickstart/native/android/00-login) tutorial), save them to access them at any time.
+Once the user credentials had been obtained (as explained in the [Login](../00-Login/TUTORIAL.md) tutorial), save them to access them at any time.
 
 The claims added to the ID Token via a Rule are included in the userinfo endpoint response. Use the Access Token to call this endpoint and obtain the user roles.
 

--- a/07-Authorization/TUTORIAL.md
+++ b/07-Authorization/TUTORIAL.md
@@ -1,5 +1,7 @@
 # Tutorial - Authorization
 
+_This content has been extracted from a previous version of the [Auth0 Android Quickstart](https://auth0.com/docs/quickstart/native/android) and demonstrates how to integrate Auth0 with an Android application using the [Auth0 Android](https://github.com/auth0/Auth0.Android) SDK._
+
 This tutorial shows you how to use Auth0 to create access roles for your users. With access roles, you can authorize or deny access to your content to different users based on the level of access they have.
 
 ## Before You Start


### PR DESCRIPTION
This change adds a new `TUTORIAL.md` to each sample application, with the content from the associated Quickstart article. The contents from the Quickstart articles are taken mostly as-is, and simply reformatted to proper Markdown, and updating any relative links in the docs site to absolute links.

This PR is one step in the process of archiving and updating the Android Quickstart articles and samples to use version 2. Following this PR, we will:
- Tag a release in this repository at the last point-in-time prior to updating for v2
- Merge the `feat-kotlin` branch to `master` in this repo, making the version on master specific to v2
- Update the currently published Android QS article with the v2 version, and link to this repository's release page for those who wish to follow a v1 tutorial