### PR TITLE
Fix value replacement [ESD-12922]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
       - image: circleci/android:api-30
     environment:
       - JVM_OPTS: -Xmx3200m
-      - AUTH0_CONFIG: strings.xml
+      - AUTH0_CONFIG: strings.xml.example
       - GRADLE_OPTS: -Dkotlin.compiler.execution.strategy=in-process
   python3:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
       - image: circleci/android:api-30
     environment:
       - JVM_OPTS: -Xmx3200m
-      - AUTH0_CONFIG: strings.xml.example
+      - AUTH0_CONFIG: strings.xml
       - GRADLE_OPTS: -Dkotlin.compiler.execution.strategy=in-process
   python3:
     docker:

--- a/00-Login-Kt/README.md
+++ b/00-Login-Kt/README.md
@@ -7,7 +7,7 @@ This sample demonstrates the following use cases:
 - Login
 - Logout
 - Showing the user profile
-- Geting the user metadata
+- Getting the user metadata
 - Updating the user metadata
 
 ## Requirements

--- a/00-Login-Kt/app/src/main/res/values/strings.xml.example
+++ b/00-Login-Kt/app/src/main/res/values/strings.xml.example
@@ -1,7 +1,7 @@
 <resources>
     <string name="app_name">Auth0 WebAuth KT</string>
 
-    <string name="com_auth0_client_id">YOUR_CLIENT_ID</string>
-    <string name="com_auth0_domain">YOUR_DOMAIN</string>
+    <string name="com_auth0_client_id">{CLIENT_ID}</string>
+    <string name="com_auth0_domain">{DOMAIN}</string>
     <string name="com_auth0_scheme">demo</string>
 </resources>


### PR DESCRIPTION
This PR adds the file `strings.xml.example` with the appropriate placeholders, and removes `strings.xml`, as the values were not being replaced.
Also fixes a typo on the Readme.

See related PR from same ESD ticket: https://github.com/auth0/docs/pull/9702