### PR TITLE
Add GitHub issue forms [SDK-4269]

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug Report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug Report.yml
@@ -1,0 +1,68 @@
+name: 🐞 Report a bug
+description: Have you found a bug or issue? Create a bug report for this sample
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Please do not report security vulnerabilities here**. The [Responsible Disclosure Program](https://auth0.com/responsible-disclosure-policy) details the procedure for disclosing security issues.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I have looked into the Readme ([Java](https://github.com/auth0-samples/auth0-android-sample/tree/master/00-Login#readme)/[Kotlin](https://github.com/auth0-samples/auth0-android-sample/tree/master/00-Login-Kt#readme)) and have not found a suitable solution or answer.
+          required: true
+        - label: I have searched the [issues](https://github.com/auth0-samples/auth0-samples/auth0-android-sample/issues) and have not found a suitable solution or answer.
+          required: true
+        - label: I have searched the [Auth0 Community](https://community.auth0.com) forums and have not found a suitable solution or answer.
+          required: true
+        - label: I agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
+          required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Provide a clear and concise description of the issue, including what you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Detail the steps taken to reproduce this error, and whether this issue can be reproduced consistently or if it is intermittent.
+      placeholder: |
+        1. Step 1...
+        2. Step 2...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Any other relevant information you think would be useful.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: environment-sample
+    attributes:
+      label: Sample
+      multiple: false
+      options:
+        - Java
+        - Kotlin
+    validations:
+      required: true
+
+  - type: input
+    id: environment-android-version
+    attributes:
+      label: Android version(s)
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/Bug Report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug Report.yml
@@ -14,7 +14,7 @@ body:
       options:
         - label: I have looked into the Readme ([Java](https://github.com/auth0-samples/auth0-android-sample/tree/master/00-Login#readme)/[Kotlin](https://github.com/auth0-samples/auth0-android-sample/tree/master/00-Login-Kt#readme)) and have not found a suitable solution or answer.
           required: true
-        - label: I have searched the [issues](https://github.com/auth0-samples/auth0-samples/auth0-android-sample/issues) and have not found a suitable solution or answer.
+        - label: I have searched the [issues](https://github.com/auth0-samples/auth0-android-sample/issues) and have not found a suitable solution or answer.
           required: true
         - label: I have searched the [Auth0 Community](https://community.auth0.com) forums and have not found a suitable solution or answer.
           required: true

--- a/.github/ISSUE_TEMPLATE/Feature Request.yml
+++ b/.github/ISSUE_TEMPLATE/Feature Request.yml
@@ -10,7 +10,7 @@ body:
       options:
         - label: I have looked into the Readme ([Base](https://github.com/auth0-samples/auth0-android-sample/tree/master/00-Login#readme)/[Kotlin](https://github.com/auth0-samples/auth0-android-sample/tree/master/00-Login-Kt#readme)) and have not found a suitable solution or answer.
           required: true
-        - label: I have searched the [issues](https://github.com/auth0-samples/auth0-samples/auth0-android-sample/issues) and have not found a suitable solution or answer.
+        - label: I have searched the [issues](https://github.com/auth0-samples/auth0-android-sample/issues) and have not found a suitable solution or answer.
           required: true
         - label: I have searched the [Auth0 Community](https://community.auth0.com) forums and have not found a suitable solution or answer.
           required: true

--- a/.github/ISSUE_TEMPLATE/Feature Request.yml
+++ b/.github/ISSUE_TEMPLATE/Feature Request.yml
@@ -1,0 +1,50 @@
+name: 🧩 Feature request
+description: Suggest an idea or a feature for this sample
+labels: ["feature request"]
+
+body:
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I have looked into the Readme ([Base](https://github.com/auth0-samples/auth0-android-sample/tree/master/00-Login#readme)/[Kotlin](https://github.com/auth0-samples/auth0-android-sample/tree/master/00-Login-Kt#readme)) and have not found a suitable solution or answer.
+          required: true
+        - label: I have searched the [issues](https://github.com/auth0-samples/auth0-samples/auth0-android-sample/issues) and have not found a suitable solution or answer.
+          required: true
+        - label: I have searched the [Auth0 Community](https://community.auth0.com) forums and have not found a suitable solution or answer.
+          required: true
+        - label: I agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
+          required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the problem you'd like to have solved
+      description: A clear and concise description of what the problem is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: ideal-solution
+    attributes:
+      label: Describe the ideal solution
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives-and-workarounds
+    attributes:
+      label: Alternatives and current workarounds
+      description: A clear and concise description of any alternatives you've considered or any workarounds that are currently in place.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🤔 Help & Questions
+    url: https://community.auth0.com
+    about: Ask general support or usage questions in the Auth0 Community forums.


### PR DESCRIPTION
### Description

This PR adds issue forms for **feature requests** and **bug reports**. This repository does not currently have any issue templates, so none was removed.

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not the default branch
